### PR TITLE
Show the autoscroll toggle on all session pages.

### DIFF
--- a/dashboard/src/components/DashboardView.tsx
+++ b/dashboard/src/components/DashboardView.tsx
@@ -620,7 +620,7 @@ function DashboardView() {
                 <CircularProgress size={18} sx={{ color: 'inherit' }} />
               </Tooltip>
             )}
-            
+
             {/* Connection Status Indicator - Subtle badge in top right */}
             <Tooltip 
               title={wsConnected 

--- a/dashboard/src/components/SessionDetailPageBase.tsx
+++ b/dashboard/src/components/SessionDetailPageBase.tsx
@@ -506,8 +506,8 @@ function SessionDetailPageBase({
           
 
 
-          {/* Auto-scroll toggle - only show for active sessions */}
-          {session && (session.status === 'in_progress' || session.status === 'pending') && (
+          {/* Auto-scroll toggle */}
+          {session && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mr: 2 }}>
               <FormControlLabel
                 control={


### PR DESCRIPTION
Not just on active active ones so that autoscroll can be switched off also when viewing the past alerts from the history.

Assisted-By: Claude Code