### PR TITLE
Non-root users for front-end and back-end images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,8 +24,16 @@ RUN uv sync --frozen
 # Copy application code
 COPY . .
 
-# Create data and logs directories
-RUN mkdir -p /app/data /app/logs
+# Create a non-root user for security
+RUN groupadd --gid 65532 appuser \
+    && useradd --uid 65532 --gid 65532 --no-create-home --shell /bin/false appuser
+
+# Create data and logs directories with proper ownership
+RUN mkdir -p /app/data /app/logs \
+    && chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER 65532:65532
 
 # Expose port
 EXPOSE 8000

--- a/config/nginx-reverse-proxy.conf
+++ b/config/nginx-reverse-proxy.conf
@@ -6,7 +6,7 @@ server {
 
     # Dashboard static files - served by dashboard nginx container
     location / {
-        proxy_pass http://dashboard:80;
+        proxy_pass http://dashboard:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -33,8 +33,19 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Copy nginx configuration into the image
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose port 80
-EXPOSE 80
+# Create a non-root user for security
+RUN addgroup -g 65532 -S appuser \
+    && adduser -u 65532 -S -G appuser appuser
+
+# Create nginx cache and run directories with proper ownership
+RUN mkdir -p /var/cache/nginx/client_temp /var/run/nginx /run \
+    && chown -R appuser:appuser /var/cache/nginx /var/run/nginx /usr/share/nginx/html /run
+
+# Switch to non-root user
+USER 65532:65532
+
+# Expose port 8080 (non-privileged port)
+EXPOSE 8080
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -1,4 +1,9 @@
 # Dashboard nginx configuration for serving React app
+
+# Redirect logs to stdout/stderr for container best practices
+error_log /dev/stderr warn;
+access_log /dev/stdout combined;
+
 server {
     listen 8080;
     server_name localhost;

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -1,6 +1,6 @@
 # Dashboard nginx configuration for serving React app
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;

--- a/docs/oauth2-proxy-setup.md
+++ b/docs/oauth2-proxy-setup.md
@@ -99,15 +99,13 @@ For production deployments:
 # Container Deployment (with OAuth2-proxy)
 make containers-deploy        # Deploy stack (rebuild apps, preserve database)
 make containers-deploy-fresh  # Deploy fresh stack (rebuild everything)
-make containers-start         # Start all containers (with build)
-make containers-start-fast    # Start containers (no build)
+make containers-start         # Start containers (no build)  
 make containers-stop          # Stop all containers
 make containers-clean         # Remove all containers and data
 
 # Container Management
 make containers-status        # Show container status
 make containers-logs          # Show logs from all containers
-make containers-build         # Build container images
 make containers-build-app     # Build only application containers
 
 # Development (no authentication)

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -39,8 +39,6 @@ services:
       - DATABASE_URL=postgresql://tarsy:tarsy-dev-password@database:5432/tarsy
     volumes:
       - ./config:/config:ro                        # Mount configuration files to expected path
-      - ./data:/app/data                           # Persist application data
-      - ./logs:/app/logs                           # Persist logs
     depends_on:
       database:
         condition: service_healthy
@@ -54,7 +52,7 @@ services:
         - VITE_API_BASE_URL=http://localhost:8080
         - VITE_WS_BASE_URL=ws://localhost:8080
     # No direct ports exposed - accessed only through reverse proxy
-    # nginx serves React production build on port 80 inside container
+    # nginx serves React production build on port 8080 inside container
     depends_on:
       - oauth2-proxy
 


### PR DESCRIPTION
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Smarter container deployment with clearer start/stop/log flows and updated help text.

* Security
  * Services now run as non-root users; dashboard serves on port 8080 and logs are redirected to stdout/stderr.

* Breaking Changes
  * Backend data/log persistence removed by default (volume mounts dropped).
  * Startup no longer builds images; several legacy container targets removed/renamed.

* Configuration
  * Reverse proxy updated to route dashboard traffic to port 8080.

* Operations/Chores
  * Centralized compose invocation; added aggressive clean, deep clean, and interactive DB reset commands.

* Documentation
  * OAuth2 proxy setup updated to reflect new start flow and removed build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->