### PR TITLE
Mark sessions killed by timeout and other errors as failed

### DIFF
--- a/backend/env.template
+++ b/backend/env.template
@@ -192,6 +192,7 @@ CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,h
 
 # Processing Limits
 # MAX_CONCURRENT_ALERTS=5
+# ALERT_PROCESSING_TIMEOUT=600      # Timeout (seconds) for processing a single alert (default: 10 minutes)
 # MAX_RUNBOOK_SIZE_MB=10
 
 # GitHub API Configuration

--- a/backend/tarsy/config/settings.py
+++ b/backend/tarsy/config/settings.py
@@ -135,9 +135,9 @@ class Settings(BaseSettings):
         default=5,
         description="Maximum number of alerts that can be processed concurrently"
     )
-    alert_queue_timeout: int = Field(
-        default=300,
-        description="Timeout in seconds for alerts waiting in queue"
+    alert_processing_timeout: int = Field(
+        default=600,
+        description="Timeout in seconds for processing a single alert (default: 10 minutes)"
     )
     
     # Agent Configuration

--- a/backend/tarsy/main.py
+++ b/backend/tarsy/main.py
@@ -365,6 +365,17 @@ async def dashboard_websocket_endpoint(websocket: WebSocket, user_id: str) -> No
     finally:
         dashboard_manager.disconnect(user_id)
 
+def mark_session_as_failed(alert: Optional[ChainContext], error_msg: str) -> None:
+    """
+    Mark a session as failed if alert context is available.
+    
+    Args:
+        alert: Alert context containing session_id
+        error_msg: Error message describing the failure
+    """
+    if alert and hasattr(alert, 'session_id') and alert_service:
+        alert_service._update_session_error(alert.session_id, error_msg)
+
 async def process_alert_background(alert_id: str, alert: ChainContext) -> None:
     """Background task to process an alert with comprehensive error handling and concurrency control."""
     if alert_processing_semaphore is None or alert_service is None:
@@ -397,21 +408,25 @@ async def process_alert_background(alert_id: str, alert: ChainContext) -> None:
             # Configuration or data validation errors
             error_msg = f"Invalid alert data: {str(e)}"
             logger.error(f"Alert {alert_id} validation failed: {error_msg}")
+            mark_session_as_failed(alert, error_msg)
             
         except TimeoutError as e:
             # Processing timeout
             error_msg = str(e)
             logger.error(f"Alert {alert_id} processing timeout: {error_msg}")
+            mark_session_as_failed(alert, error_msg)
             
         except ConnectionError as e:
             # Network or external service errors
             error_msg = f"Connection error during processing: {str(e)}"
             logger.error(f"Alert {alert_id} connection error: {error_msg}")
+            mark_session_as_failed(alert, error_msg)
             
         except MemoryError as e:
             # Memory issues with large payloads
             error_msg = "Processing failed due to memory constraints (payload too large)"
             logger.error(f"Alert {alert_id} memory error: {error_msg}")
+            mark_session_as_failed(alert, error_msg)
             
         except Exception as e:
             # Catch-all for unexpected errors
@@ -420,6 +435,7 @@ async def process_alert_background(alert_id: str, alert: ChainContext) -> None:
             logger.exception(
                 f"Alert {alert_id} unexpected error after {duration:.2f}s: {error_msg}"
             )
+            mark_session_as_failed(alert, error_msg)
         
         finally:
             # Clean up alert key tracking regardless of success or failure

--- a/backend/tarsy/main.py
+++ b/backend/tarsy/main.py
@@ -392,13 +392,14 @@ async def process_alert_background(alert_id: str, alert: ChainContext) -> None:
             
             # Process with timeout to prevent hanging
             try:
-                # Set a reasonable timeout (e.g., 10 minutes for alert processing)
+                # Use configurable timeout for alert processing
+                timeout_seconds = settings.alert_processing_timeout
                 await asyncio.wait_for(
                     alert_service.process_alert(alert, alert_id=alert_id),
-                    timeout=600  # 10 minutes
+                    timeout=timeout_seconds
                 )
             except asyncio.TimeoutError:
-                raise TimeoutError(f"Alert processing exceeded timeout limit of 10 minutes")
+                raise TimeoutError(f"Alert processing exceeded timeout limit of {timeout_seconds}s")
             
             # Calculate processing duration
             duration = (datetime.now() - start_time).total_seconds()


### PR DESCRIPTION
Also makes this timeout configurable (10m by default)