### PR TITLE
Fix: submit-allert session stuck in progress if faild to download runbook

### DIFF
--- a/backend/tarsy/services/alert_service.py
+++ b/backend/tarsy/services/alert_service.py
@@ -742,7 +742,7 @@ class AlertService:
         
         Args:
             session_id: Session ID to complete
-            status: Final status (e.g., 'completed', 'error')
+            status: Final status (must be from AlertSessionStatus enum: 'completed' or 'failed')
             final_analysis: Final formatted analysis if status is completed successfully
         """
         try:

--- a/backend/tarsy/services/dashboard_update_service.py
+++ b/backend/tarsy/services/dashboard_update_service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from tarsy.utils.logger import get_module_logger
 
+from tarsy.models.constants import AlertSessionStatus
 from tarsy.services.dashboard_broadcaster import DashboardBroadcaster
 
 logger = get_module_logger(__name__)
@@ -193,7 +194,6 @@ class DashboardUpdateService:
         
         # Move to history if session is completed
         # Use enum to ensure we catch all terminal statuses consistently
-        from tarsy.models.constants import AlertSessionStatus
         if status in AlertSessionStatus.terminal_values():
             self._archive_session(session_id)
             logger.debug(f"Archived session {session_id} after terminal status: {status}")
@@ -234,7 +234,7 @@ class DashboardUpdateService:
         if session_id not in self.active_sessions:
             self.active_sessions[session_id] = SessionSummary(
                 session_id=session_id,
-                status="active",
+                status=AlertSessionStatus.IN_PROGRESS.value,
                 start_time=datetime.now(),
                 last_activity=datetime.now()
             )
@@ -252,7 +252,7 @@ class DashboardUpdateService:
         if session_id not in self.active_sessions:
             self.active_sessions[session_id] = SessionSummary(
                 session_id=session_id,
-                status="active",
+                status=AlertSessionStatus.IN_PROGRESS.value,
                 start_time=datetime.now(),
                 last_activity=datetime.now()
             )

--- a/backend/tests/unit/services/test_dashboard_connection_manager.py
+++ b/backend/tests/unit/services/test_dashboard_connection_manager.py
@@ -87,14 +87,15 @@ class TestDashboardConnectionManager:
         ("test_user", ChannelType.DASHBOARD_UPDATES, True, True),  # Active user subscription
         ("inactive_user", ChannelType.DASHBOARD_UPDATES, False, False),  # Inactive user subscription
     ])
+    @pytest.mark.asyncio
     @pytest.mark.unit
-    def test_subscribe_scenarios(self, connection_manager, mock_websocket, user_id, channel, is_active, expected_success):
+    async def test_subscribe_scenarios(self, connection_manager, mock_websocket, user_id, channel, is_active, expected_success):
         """Test subscribing users to channels for various scenarios."""
         if is_active:
             # Set up connection
             connection_manager.active_connections[user_id] = mock_websocket
         
-        success = connection_manager.subscribe_to_channel(user_id, channel)
+        success = await connection_manager.subscribe_to_channel(user_id, channel)
         
         assert success is expected_success
         if expected_success:

--- a/backend/tests/unit/services/test_dashboard_connection_manager.py
+++ b/backend/tests/unit/services/test_dashboard_connection_manager.py
@@ -106,6 +106,57 @@ class TestDashboardConnectionManager:
             assert user_id in connection_manager.user_subscriptions
             assert len(connection_manager.user_subscriptions[user_id]) == 0
 
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_session_channel_subscription_flushes_buffer(self, connection_manager, mock_websocket):
+        """Test that subscribing to a session channel triggers buffer flush."""
+        from unittest.mock import AsyncMock, MagicMock
+        
+        # Setup mock broadcaster
+        mock_broadcaster = MagicMock()
+        mock_broadcaster.flush_session_buffer = AsyncMock()
+        connection_manager.broadcaster = mock_broadcaster
+        
+        # Setup active connection
+        user_id = "test_user"
+        session_channel = "session_abc123"
+        connection_manager.active_connections[user_id] = mock_websocket
+        
+        # Subscribe to session channel
+        success = await connection_manager.subscribe_to_channel(user_id, session_channel)
+        
+        # Verify subscription succeeded
+        assert success is True
+        assert session_channel in connection_manager.user_subscriptions[user_id]
+        
+        # Verify buffer flush was called for session channel
+        mock_broadcaster.flush_session_buffer.assert_called_once_with(session_channel)
+    
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_session_channel_subscription_no_flush(self, connection_manager, mock_websocket):
+        """Test that subscribing to non-session channels does NOT trigger buffer flush."""
+        from unittest.mock import AsyncMock, MagicMock
+        
+        # Setup mock broadcaster
+        mock_broadcaster = MagicMock()
+        mock_broadcaster.flush_session_buffer = AsyncMock()
+        connection_manager.broadcaster = mock_broadcaster
+        
+        # Setup active connection
+        user_id = "test_user"
+        connection_manager.active_connections[user_id] = mock_websocket
+        
+        # Subscribe to dashboard channel (non-session)
+        success = await connection_manager.subscribe_to_channel(user_id, ChannelType.DASHBOARD_UPDATES)
+        
+        # Verify subscription succeeded
+        assert success is True
+        assert ChannelType.DASHBOARD_UPDATES in connection_manager.user_subscriptions[user_id]
+        
+        # Verify buffer flush was NOT called for non-session channel
+        mock_broadcaster.flush_session_buffer.assert_not_called()
+
     @pytest.mark.unit
     def test_unsubscribe_from_channel(self, connection_manager, mock_websocket):
         """Test unsubscribing user from a channel."""

--- a/backend/tests/unit/services/test_dashboard_update_service.py
+++ b/backend/tests/unit/services/test_dashboard_update_service.py
@@ -156,7 +156,7 @@ class TestLLMInteractionProcessing:
         assert session.llm_interactions == 1
         assert session.interactions_count == 1
         assert session.errors_count == 0
-        assert session.status == "active"
+        assert session.status == "in_progress"
     
     @pytest.mark.asyncio
     @pytest.mark.unit
@@ -213,7 +213,7 @@ class TestMCPInteractionProcessing:
         assert session.interactions_count == 1
         assert session.errors_count == 0
 
-        assert session.status == "active"
+        assert session.status == "in_progress"
         
         # Verify broadcast was called
         mock_broadcaster.broadcast_session_update.assert_called_once()
@@ -389,7 +389,7 @@ class TestSessionArchiving:
         "completed",
         "failed",
     ])
-    async def test_terminal_statuses_archive_session(self, update_service, mock_broadcaster, terminal_status):
+    async def test_terminal_statuses_archive_session(self, update_service, terminal_status):
         """Test that all terminal statuses properly archive sessions.
         
         This test uses AlertSessionStatus enum values to ensure sessions are archived
@@ -427,7 +427,7 @@ class TestSessionArchiving:
         "pending",
         "in_progress",
     ])
-    async def test_non_terminal_statuses_do_not_archive(self, update_service, mock_broadcaster, non_terminal_status):
+    async def test_non_terminal_statuses_do_not_archive(self, update_service, non_terminal_status):
         """Test that non-terminal statuses do NOT archive sessions."""
         from tarsy.models.constants import AlertSessionStatus
         
@@ -452,7 +452,7 @@ class TestSessionArchiving:
     
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_failed_status_archives_session_with_error(self, update_service, mock_broadcaster):
+    async def test_failed_status_archives_session_with_error(self, update_service):
         """Test that 'failed' status properly archives session with error details.
         
         This specifically tests the bug fix where 'failed' status wasn't being
@@ -487,7 +487,7 @@ class TestSessionArchiving:
     
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_multiple_status_transitions_final_archive(self, update_service, mock_broadcaster):
+    async def test_multiple_status_transitions_final_archive(self, update_service):
         """Test session through multiple status transitions, ensuring final terminal status archives."""
         
         session_id = "transition_session"

--- a/backend/tests/unit/services/test_dashboard_update_service.py
+++ b/backend/tests/unit/services/test_dashboard_update_service.py
@@ -332,7 +332,7 @@ class TestSessionStatusManagement:
         new_status = "completed"
         details = {"progress_percentage": 100}
         
-        sent_count = await update_service.process_session_status_change(session_id, new_status, details)
+        await update_service.process_session_status_change(session_id, new_status, details)
         
         # Verify session was updated but start_time preserved
         session = update_service.active_sessions.get(session_id)  # May be None if archived
@@ -343,10 +343,8 @@ class TestSessionStatusManagement:
             assert session.progress_percentage == 100
             assert session.start_time == original_session.start_time  # Preserved
         
-        # Verify session was archived for completion statuses
-        if new_status in ["completed", "error", "timeout"]:
-            # Session should be removed from active sessions
-            assert session_id not in update_service.active_sessions
+        # Verify session archiving behavior is tested in dedicated test class below
+        # (See TestSessionArchiving for comprehensive archiving tests)
     
     @pytest.mark.asyncio
     @pytest.mark.unit
@@ -366,6 +364,146 @@ class TestSessionStatusManagement:
         await update_service.process_session_status_change(session_id, "completed")
         
         # Verify session was archived (removed from active sessions)
+        assert session_id not in update_service.active_sessions
+
+
+class TestSessionArchiving:
+    """Test session archiving with terminal statuses using enum values."""
+    
+    @pytest.fixture
+    def mock_broadcaster(self):
+        """Mock broadcaster."""
+        broadcaster = AsyncMock()
+        broadcaster.broadcast_dashboard_update = AsyncMock(return_value=3)
+        broadcaster.broadcast_session_update = AsyncMock(return_value=2)
+        return broadcaster
+    
+    @pytest.fixture
+    def update_service(self, mock_broadcaster):
+        """Create service instance."""
+        return DashboardUpdateService(mock_broadcaster)
+    
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.parametrize("terminal_status", [
+        "completed",
+        "failed",
+    ])
+    async def test_terminal_statuses_archive_session(self, update_service, mock_broadcaster, terminal_status):
+        """Test that all terminal statuses properly archive sessions.
+        
+        This test uses AlertSessionStatus enum values to ensure sessions are archived
+        for all terminal statuses. This would have caught the bug where 'failed' 
+        sessions weren't being archived because the code checked for 'error' instead.
+        """
+        from tarsy.models.constants import AlertSessionStatus
+        
+        # Verify test is using actual enum values
+        assert terminal_status in AlertSessionStatus.terminal_values()
+        
+        session_id = f"session_{terminal_status}"
+        
+        # Create active session
+        update_service.active_sessions[session_id] = SessionSummary(
+            session_id=session_id,
+            status="in_progress",
+            llm_interactions=3,
+            mcp_communications=2
+        )
+        
+        # Verify session exists before status change
+        assert session_id in update_service.active_sessions
+        
+        # Update to terminal status
+        await update_service.process_session_status_change(session_id, terminal_status)
+        
+        # Verify session was archived (removed from active sessions)
+        assert session_id not in update_service.active_sessions, \
+            f"Session with status '{terminal_status}' should be archived but wasn't"
+    
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    @pytest.mark.parametrize("non_terminal_status", [
+        "pending",
+        "in_progress",
+    ])
+    async def test_non_terminal_statuses_do_not_archive(self, update_service, mock_broadcaster, non_terminal_status):
+        """Test that non-terminal statuses do NOT archive sessions."""
+        from tarsy.models.constants import AlertSessionStatus
+        
+        # Verify test is using actual enum values
+        assert non_terminal_status in AlertSessionStatus.active_values()
+        
+        session_id = f"session_{non_terminal_status}"
+        
+        # Create session
+        update_service.active_sessions[session_id] = SessionSummary(
+            session_id=session_id,
+            status="pending",
+            llm_interactions=1
+        )
+        
+        # Update to non-terminal status
+        await update_service.process_session_status_change(session_id, non_terminal_status)
+        
+        # Verify session was NOT archived (still in active sessions)
+        assert session_id in update_service.active_sessions, \
+            f"Session with status '{non_terminal_status}' should NOT be archived but was"
+    
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_failed_status_archives_session_with_error(self, update_service, mock_broadcaster):
+        """Test that 'failed' status properly archives session with error details.
+        
+        This specifically tests the bug fix where 'failed' status wasn't being
+        recognized as a terminal status because the code was checking for 'error'.
+        """
+        from tarsy.models.constants import AlertSessionStatus
+        
+        session_id = "failed_session_with_error"
+        error_message = "Processing failed due to invalid GitHub token"
+        
+        # Create active session
+        update_service.active_sessions[session_id] = SessionSummary(
+            session_id=session_id,
+            status="in_progress",
+            llm_interactions=2,
+            errors_count=1
+        )
+        
+        # Verify session exists
+        assert session_id in update_service.active_sessions
+        
+        # Update to failed status with error details
+        await update_service.process_session_status_change(
+            session_id, 
+            AlertSessionStatus.FAILED.value,
+            details={"error_message": error_message}
+        )
+        
+        # Verify session was archived despite being a failure
+        assert session_id not in update_service.active_sessions, \
+            "Failed session should be archived but wasn't - this was the original bug!"
+    
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_multiple_status_transitions_final_archive(self, update_service, mock_broadcaster):
+        """Test session through multiple status transitions, ensuring final terminal status archives."""
+        
+        session_id = "transition_session"
+        
+        # Start with pending
+        await update_service.process_session_status_change(session_id, "pending")
+        assert session_id in update_service.active_sessions
+        
+        # Move to in_progress
+        await update_service.process_session_status_change(session_id, "in_progress")
+        assert session_id in update_service.active_sessions
+        
+        # Move to completed (terminal)
+        await update_service.process_session_status_change(session_id, "completed")
+        
+        # Should be archived now
         assert session_id not in update_service.active_sessions
 
 

--- a/dashboard/src/components/AlertProcessingStatus.tsx
+++ b/dashboard/src/components/AlertProcessingStatus.tsx
@@ -155,12 +155,10 @@ const AlertProcessingStatus: React.FC<ProcessingStatusProps> = ({ alertId, onCom
     
     // Handle session-specific updates
     const handleSessionUpdate = (update: any) => {
-      
       // Handle different types of updates
       let updatedStatus: ProcessingStatus | null = null;
 
       if (update.type === 'session_status_change') {
-        console.log('📋 Session status changed to:', update.status);
         updatedStatus = {
           alert_id: alertId,
           status: update.status === 'completed' ? 'completed' : 

--- a/dashboard/src/components/ManualAlertSubmission.tsx
+++ b/dashboard/src/components/ManualAlertSubmission.tsx
@@ -85,6 +85,7 @@ function ManualAlertSubmission() {
             <Box>
               {currentAlert && (
                 <AlertProcessingStatus
+                  key={currentAlert.alert_id}
                   alertId={currentAlert.alert_id}
                   onComplete={handleProcessingComplete}
                 />
@@ -100,6 +101,7 @@ function ManualAlertSubmission() {
               {currentAlert && (
                 <>
                   <AlertProcessingStatus
+                    key={currentAlert.alert_id}
                     alertId={currentAlert.alert_id}
                     onComplete={handleProcessingComplete}
                   />

--- a/dashboard/src/services/websocket.ts
+++ b/dashboard/src/services/websocket.ts
@@ -295,7 +295,18 @@ class WebSocketService {
         if (!message.data) {
           return;
         }
+        // Call generic session update handlers
         this.eventHandlers.sessionUpdate.forEach(handler => handler(message.data!));
+        
+        // Also call session-specific handlers for this session
+        // This is needed for buffered messages that come through as 'session_update'
+        if (message.session_id) {
+          const sessionChannel = `session_${message.session_id}`;
+          const sessionHandlers = this.eventHandlers.sessionSpecific.get(sessionChannel);
+          if (sessionHandlers && sessionHandlers.length > 0) {
+            sessionHandlers.forEach(handler => handler(message.data!));
+          }
+        }
         
         // Also handle session-specific updates if this message has a channel
         if (message.channel && message.channel.startsWith('session_')) {

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -210,6 +210,7 @@ export interface WebSocketMessage {
   data?: SessionUpdate | ChainProgressUpdate | StageProgressUpdate | any; // Allow any data type for dashboard_update messages
   timestamp_us?: number; // Unix timestamp (microseconds since epoch)
   channel?: string; // Dashboard updates include channel info
+  session_id?: string; // Session ID for buffered session updates
   messages?: WebSocketMessage[]; // For message_batch type
   count?: number; // For message_batch type
   timestamp?: string; // Alternative timestamp format for batches


### PR DESCRIPTION
1. Use incorrect github token
2. Submit alert using dashbaord
3. When it fails then click on "submit another alert"
4. Now the alert is shown as progressing despite the fact that it actually failed (and properly marked as such in backend)

The workaround was to hard refresh the browser between submitting alerts. This PR fixes the issue. 

There were also a few related issues but the backend changes are mostly just cleanup and more robust status update mechanism plus better error handling for sessions which fail very quickly before the client can subscribe to the updates.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Session updates are buffered when no subscribers are present, can be flushed on demand, and are auto-flushed when subscribers join.
  - WebSocket messages may include an optional session_id for session-scoped dispatching.
  - Session summaries expose interaction, error, and progress metrics.

- Bug Fixes
  - Prevents dropped session updates and improves real-time delivery reliability.

- Refactor
  - Standardized session status handling using a status enum for consistent terminal detection and archival.

- Tests
  - Expanded tests for archiving, broadcasting, and subscription-flush scenarios.

- Style
  - Removed stray console logging and added React list keys for stable rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->