### PR TITLE
fix(dashboard): prevent duration from disappearing when session completes

### DIFF
--- a/dashboard/src/components/ProgressIndicator.tsx
+++ b/dashboard/src/components/ProgressIndicator.tsx
@@ -28,8 +28,8 @@ function ProgressIndicator({
 
   // Calculate live duration for active sessions or as fallback for completed sessions
   const getLiveDuration = () => {
-    if (duration) return duration; // Use final duration if available
-    if (startedAt) {
+    if (duration !== undefined && duration !== null) return duration; // Use final duration if available
+    if (startedAt !== undefined && startedAt !== null) {
       const now = Date.now() * 1000; // Convert to microseconds
       return Math.max(0, (now - startedAt) / 1000); // Convert to milliseconds
     }
@@ -39,7 +39,7 @@ function ProgressIndicator({
   // Live ticking timer for active sessions
   useEffect(() => {
     // Only start timer for active sessions without final duration
-    if ((status === 'in_progress' || status === 'pending') && startedAt && !duration) {
+    if ((status === 'in_progress' || status === 'pending') && startedAt !== undefined && startedAt !== null && !duration) {
       // Update immediately
       setLiveDuration(getLiveDuration());
       


### PR DESCRIPTION
Calculate duration from startedAt for all session states, not just active ones. This ensures the duration remains visible during the transition from in_progress to completed, until the final duration is received from the backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified duration calculation so active and completed sessions derive displayed time the same way.
  * Completed sessions now show a calculated duration when an explicit duration is missing.
  * Timer updates are more consistent and guarded against missing start times.

* **Bug Fixes**
  * Fixed blank or stale durations for completed sessions.
  * Removed discrepancies between live and displayed session durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->