### PR TITLE
Remove backend port 8000 from backend Service

### DIFF
--- a/deploy/kustomize/base/services.yaml
+++ b/deploy/kustomize/base/services.yaml
@@ -20,9 +20,6 @@ spec:
   selector:
     component: backend
   ports:
-    - name: http
-      port: 8000
-      targetPort: 8000
     - name: oauth2-proxy
       port: 4180
       targetPort: 4180


### PR DESCRIPTION
All traffic must now go through OAuth2 Proxy (4180), preventing direct unauthenticated access to backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Streamlined service exposure by removing the backend’s direct port (8000); the service now only exposes the OAuth2 proxy port (4180).
  * User impact: direct requests to the backend on port 8000 will fail. Access the application through the existing proxy endpoint as before (no changes to URLs behind the proxy). Monitoring and health checks should also target the proxy-exposed port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->