### PR TITLE
Add route to health prob

### DIFF
--- a/config/oauth2-proxy-container.cfg.example
+++ b/config/oauth2-proxy-container.cfg.example
@@ -17,8 +17,8 @@ reverse_proxy = true
 redirect_url = "http://localhost:8080/oauth2/callback"     # Local containers: make containers-deploy
 
 ## the http url(s) of the upstream endpoint. If multiple, routing is based on path
-# upstreams = ["http://dev-tarsy-backend:8000"]  # OpenShift deployment
-upstreams = ["http://backend:8000"]              # Local containers
+# upstreams = ["http://localhost:8000"]  # OpenShift deployment (sidecar container)
+upstreams = ["http://backend:8000"]      # Local containers (podman-compose)
 
 # Protect Existing Endpoints
 # - **Main.py endpoints**

--- a/deploy/kustomize/base/routes.yaml
+++ b/deploy/kustomize/base/routes.yaml
@@ -1,3 +1,23 @@
+# Health check route (backend through OAuth2 proxy)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tarsy-health
+  namespace: tarsy
+spec:
+  host: {{ROUTE_HOST}}
+  path: /health
+  to:
+    kind: Service
+    name: dev-tarsy-backend
+    weight: 100
+  port:
+    targetPort: 4180
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+---
 # Main dashboard route
 apiVersion: route.openshift.io/v1
 kind: Route


### PR DESCRIPTION
It's used by UI to show the backend version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated health check route for OpenShift deployments, enabling secure access to the app’s /health endpoint with TLS and automatic HTTP-to-HTTPS redirects.

* **Documentation**
  * Updated the example OAuth2 proxy configuration comments to clarify upstream targets for OpenShift sidecars and local container setups, improving guidance without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->