### PR TITLE
Add cluster context instructions to kube mcp

### DIFF
--- a/backend/tarsy/config/builtin_config.py
+++ b/backend/tarsy/config/builtin_config.py
@@ -102,6 +102,10 @@ BUILTIN_MCP_SERVERS: Dict[str, Dict[str, Any]] = {
         #     "timeout": 10
         # },
         "instructions": """For Kubernetes operations:
+- **IMPORTANT: In multi-cluster environments** (when the 'configuration_contexts_list' tool is available):
+  * ALWAYS start by calling 'configuration_contexts_list' to see all available contexts and their server URLs
+  * Use this information to determine which context to target before performing any operations
+  * This prevents working on the wrong cluster and helps you understand the environment
 - Be careful with cluster-scoped resource listings in large clusters
 - Always prefer namespaced queries when possible
 - If you get "server could not find the requested resource" error, check if you're using the namespace parameter correctly:

--- a/backend/tests/e2e/expected_conversations.py
+++ b/backend/tests/e2e/expected_conversations.py
@@ -49,6 +49,10 @@ Focus on root cause analysis and sustainable solutions.
 ## Kubernetes Server Instructions
 
 For Kubernetes operations:
+- **IMPORTANT: In multi-cluster environments** (when the 'configuration_contexts_list' tool is available):
+  * ALWAYS start by calling 'configuration_contexts_list' to see all available contexts and their server URLs
+  * Use this information to determine which context to target before performing any operations
+  * This prevents working on the wrong cluster and helps you understand the environment
 - Be careful with cluster-scoped resource listings in large clusters
 - Always prefer namespaced queries when possible
 - If you get "server could not find the requested resource" error, check if you're using the namespace parameter correctly:
@@ -294,6 +298,10 @@ Focus on root cause analysis and sustainable solutions.
 ## Kubernetes Server Instructions
 
 For Kubernetes operations:
+- **IMPORTANT: In multi-cluster environments** (when the 'configuration_contexts_list' tool is available):
+  * ALWAYS start by calling 'configuration_contexts_list' to see all available contexts and their server URLs
+  * Use this information to determine which context to target before performing any operations
+  * This prevents working on the wrong cluster and helps you understand the environment
 - Be careful with cluster-scoped resource listings in large clusters
 - Always prefer namespaced queries when possible
 - If you get "server could not find the requested resource" error, check if you're using the namespace parameter correctly:
@@ -583,6 +591,10 @@ Focus on root cause analysis and sustainable solutions.
 ## Kubernetes Server Instructions
 
 For Kubernetes operations:
+- **IMPORTANT: In multi-cluster environments** (when the 'configuration_contexts_list' tool is available):
+  * ALWAYS start by calling 'configuration_contexts_list' to see all available contexts and their server URLs
+  * Use this information to determine which context to target before performing any operations
+  * This prevents working on the wrong cluster and helps you understand the environment
 - Be careful with cluster-scoped resource listings in large clusters
 - Always prefer namespaced queries when possible
 - If you get "server could not find the requested resource" error, check if you're using the namespace parameter correctly:

--- a/dashboard/src/components/AlertProcessingStatus.tsx
+++ b/dashboard/src/components/AlertProcessingStatus.tsx
@@ -14,11 +14,15 @@ import {
   Alert,
   Chip,
   Paper,
+  Button,
+  Tooltip,
 } from '@mui/material';
 import {
   CheckCircle as CheckCircleIcon,
   Error as ErrorIcon,
   HourglassTop as HourglassIcon,
+  OpenInNew as OpenInNewIcon,
+  Visibility as VisibilityIcon,
 } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
 
@@ -256,6 +260,14 @@ const AlertProcessingStatus: React.FC<ProcessingStatusProps> = ({ sessionId, onC
     );
   }
 
+  // Handle opening alert detail view
+  const handleViewDetails = () => {
+    if (status?.session_id) {
+      const url = `${window.location.origin}/sessions/${status.session_id}`;
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   return (
     <Box>
       <Card sx={{ mb: 3 }}>
@@ -274,9 +286,38 @@ const AlertProcessingStatus: React.FC<ProcessingStatusProps> = ({ sessionId, onC
             </Box>
           </Box>
 
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            Session ID: {status.session_id}
-          </Typography>
+          <Box 
+            display="flex" 
+            alignItems="center" 
+            justifyContent="space-between" 
+            flexWrap="wrap"
+            gap={2}
+            mb={2}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Session ID: {status.session_id}
+            </Typography>
+            
+            <Tooltip title="Open detailed alert view in new tab" arrow>
+              <Button
+                variant="contained"
+                color="success"
+                size="medium"
+                startIcon={<VisibilityIcon />}
+                endIcon={<OpenInNewIcon />}
+                onClick={handleViewDetails}
+                sx={{ 
+                  boxShadow: 2,
+                  px: 2.5,
+                  '&:hover': {
+                    boxShadow: 4,
+                  }
+                }}
+              >
+                View Full Details
+              </Button>
+            </Tooltip>
+          </Box>
 
           <Box mb={3}>
             <Typography variant="body1" gutterBottom>


### PR DESCRIPTION
Also add "View full details" button to the submit-alert view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added View Full Details button to alert processing status view for quick access to detailed alert information in a new tab.

* **Documentation**
  * Enhanced Kubernetes instructions with improved multi-cluster guidance to help users enumerate contexts and select the correct cluster environment before operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->