### PR TITLE
implement the database layer for session scoring

### DIFF
--- a/backend/alembic/versions/20260202_1721_776dca9d9a2f_add_session_scores_table.py
+++ b/backend/alembic/versions/20260202_1721_776dca9d9a2f_add_session_scores_table.py
@@ -1,0 +1,100 @@
+"""add_session_scores_table
+
+Revision ID: 776dca9d9a2f
+Revises: b67c135119d7
+Create Date: 2026-01-13 17:21:32.869647
+
+Adds session_scores table for alert session scoring API (EP-0028):
+- Tracks scoring attempts for alert sessions
+- Stores prompt hash for detecting stale scores
+- Async status tracking (pending -> in_progress -> completed/failed)
+- Partial unique constraint prevents duplicate concurrent scoring attempts
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "776dca9d9a2f"
+down_revision: Union[str, Sequence[str], None] = "b67c135119d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create session_scores table with indexes and constraints."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "session_scores" not in existing_tables:
+        # Create table
+        op.create_table(
+            "session_scores",
+            sa.Column("score_id", sa.String(), nullable=False),
+            sa.Column("session_id", sa.String(), nullable=False),
+            sa.Column("prompt_hash", sa.String(length=64), nullable=False),
+            sa.Column("total_score", sa.Integer(), nullable=True),
+            sa.Column("score_analysis", sa.Text(), nullable=True),
+            sa.Column("missing_tools_analysis", sa.Text(), nullable=True),
+            sa.Column("score_triggered_by", sa.String(length=255), nullable=False),
+            sa.Column("scored_at_us", sa.BIGINT(), nullable=False),
+            sa.Column("status", sa.String(length=50), nullable=False),
+            sa.Column("started_at_us", sa.BIGINT(), nullable=False),
+            sa.Column("completed_at_us", sa.BIGINT(), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["session_id"],
+                ["alert_sessions.session_id"],
+                name="fk_session_scores_session",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("score_id"),
+        )
+
+        # Create indexes
+        op.create_index(
+            "ix_session_scores_session_id", "session_scores", ["session_id"]
+        )
+        op.create_index(
+            "ix_session_scores_prompt_hash", "session_scores", ["prompt_hash"]
+        )
+        op.create_index(
+            "ix_session_scores_total_score", "session_scores", ["total_score"]
+        )
+        op.create_index("ix_session_scores_status", "session_scores", ["status"])
+        op.create_index(
+            "ix_session_scores_session_status",
+            "session_scores",
+            ["session_id", "status"],
+        )
+        op.create_index(
+            "ix_session_scores_status_started",
+            "session_scores",
+            ["status", "started_at_us"],
+        )
+
+        # Create partial unique index (prevents duplicate active scorings)
+        op.execute("""
+            CREATE UNIQUE INDEX ix_session_scores_unique_active
+            ON session_scores(session_id)
+            WHERE status IN ('pending', 'in_progress')
+        """)
+
+
+def downgrade() -> None:
+    """Drop session_scores table."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "session_scores" in existing_tables:
+        # Drop partial unique index
+        op.execute("DROP INDEX IF EXISTS ix_session_scores_unique_active")
+
+        # Drop table (indexes drop automatically)
+        op.drop_table("session_scores")

--- a/backend/tarsy/models/api_models.py
+++ b/backend/tarsy/models/api_models.py
@@ -10,71 +10,94 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from tarsy.models.constants import ChainStatus
+from tarsy.models.constants import ChainStatus, ScoringStatus
 
 # Non-history related response models
 
+
 class HealthCheckResponse(BaseModel):
     """Response for health check endpoints."""
+
     service: str = Field(description="Service name")
-    status: str = Field(description="Service status ('healthy', 'unhealthy', 'disabled')")
-    timestamp_us: int = Field(description="Health check timestamp (microseconds since epoch UTC)")
+    status: str = Field(
+        description="Service status ('healthy', 'unhealthy', 'disabled')"
+    )
+    timestamp_us: int = Field(
+        description="Health check timestamp (microseconds since epoch UTC)"
+    )
     details: Dict[str, Any] = Field(description="Additional health check details")
+
 
 class ErrorResponse(BaseModel):
     """Standard error response model."""
+
     error: str = Field(description="Error type or category")
     message: str = Field(description="Human-readable error message")
     details: Optional[Dict[str, Any]] = Field(description="Additional error details")
-    timestamp_us: int = Field(description="When the error occurred (microseconds since epoch UTC)")
+    timestamp_us: int = Field(
+        description="When the error occurred (microseconds since epoch UTC)"
+    )
+
 
 class ChainExecutionResult(BaseModel):
     """
     Result from chain execution.
-    
+
     This model represents the result of executing a chain of agent stages,
     containing both success and failure information.
     """
-    
+
     # Core execution metadata - always present
     status: ChainStatus = Field(description="Overall execution status")
-    timestamp_us: int = Field(description="Execution completion timestamp (microseconds since epoch UTC)")
-    
+    timestamp_us: int = Field(
+        description="Execution completion timestamp (microseconds since epoch UTC)"
+    )
+
     # Success case fields - present when status is completed or partial
-    final_analysis: Optional[str] = Field(None, description="Final analysis result from the chain")
-    
+    final_analysis: Optional[str] = Field(
+        None, description="Final analysis result from the chain"
+    )
+
     # Error case fields - present when status is failed
     error: Optional[str] = Field(None, description="Error message when execution fails")
 
 
 # ===== Chat API Models =====
 
+
 class ChatResponse(BaseModel):
     """Response for chat creation endpoint."""
+
     chat_id: str = Field(description="Unique chat identifier")
     session_id: str = Field(description="Original session ID")
-    created_at_us: int = Field(description="Chat creation timestamp (microseconds since epoch UTC)")
+    created_at_us: int = Field(
+        description="Chat creation timestamp (microseconds since epoch UTC)"
+    )
     created_by: str = Field(description="User who initiated the chat")
     message_count: int = Field(default=0, description="Number of messages in chat")
 
 
 class ChatAvailabilityResponse(BaseModel):
     """Response for chat availability check endpoint."""
+
     available: bool = Field(description="Whether chat is available for this session")
     reason: Optional[str] = Field(default=None, description="Reason if unavailable")
-    chat_id: Optional[str] = Field(default=None, description="Existing chat ID if already created")
+    chat_id: Optional[str] = Field(
+        default=None, description="Existing chat ID if already created"
+    )
 
 
 class ChatMessageRequest(BaseModel):
     """Request body for sending chat message."""
+
     content: str = Field(
-        ..., 
-        min_length=1, 
+        ...,
+        min_length=1,
         max_length=100000,
-        description="User's question or follow-up message"
+        description="User's question or follow-up message",
     )
-    
-    @field_validator('content')
+
+    @field_validator("content")
     @classmethod
     def validate_content(cls, v: str) -> str:
         """Ensure content is not just whitespace."""
@@ -85,25 +108,81 @@ class ChatMessageRequest(BaseModel):
 
 class ChatMessageResponse(BaseModel):
     """Response for message creation endpoint."""
+
     message_id: str = Field(description="Unique message identifier")
     chat_id: str = Field(description="Parent chat ID")
     content: str = Field(description="Message content")
     author: str = Field(description="Message author")
-    created_at_us: int = Field(description="Message timestamp (microseconds since epoch UTC)")
-    stage_execution_id: Optional[str] = Field(default=None, description="Stage execution ID for AI response (streams via WebSocket)")
+    created_at_us: int = Field(
+        description="Message timestamp (microseconds since epoch UTC)"
+    )
+    stage_execution_id: Optional[str] = Field(
+        default=None,
+        description="Stage execution ID for AI response (streams via WebSocket)",
+    )
 
 
 class ChatUserMessageListResponse(BaseModel):
     """Response for chat message history endpoint."""
+
     messages: List[ChatMessageResponse] = Field(description="List of user messages")
     total_count: int = Field(description="Total message count")
     chat_id: str = Field(description="Chat identifier")
 
 
+# ===== Scoring API Models =====
+
+
+class SessionScoreResponse(BaseModel):
+    """
+    Session scoring result for API responses.
+
+    Includes computed field to indicate if score uses current prompt template.
+    """
+
+    score_id: str = Field(description="Unique scoring attempt identifier")
+    session_id: str = Field(description="Alert session that was scored")
+    prompt_hash: str = Field(description="Hash of prompt template used for scoring")
+    total_score: Optional[int] = Field(
+        None, ge=0, le=100, description="Total score (0-100), None if not yet completed"
+    )
+    score_analysis: Optional[str] = Field(None, description="Detailed scoring analysis")
+    missing_tools_analysis: Optional[str] = Field(
+        None, description="Missing tools analysis"
+    )
+    score_triggered_by: str = Field(description="Who/what triggered the scoring")
+    scored_at_us: int = Field(
+        description="When scoring was initiated (microseconds since epoch)"
+    )
+
+    # Async status fields
+    status: ScoringStatus = Field(
+        description="Scoring status (pending|in_progress|completed|failed|timed_out)"
+    )
+    started_at_us: int = Field(
+        description="Processing start time (microseconds since epoch)"
+    )
+    completed_at_us: Optional[int] = Field(
+        None, description="Processing end time (microseconds since epoch)"
+    )
+    error_message: Optional[str] = Field(None, description="Error details if failed")
+
+    # Computed field (set to False in Phase 1, will be calculated in Phase 2)
+    current_prompt_used: bool = Field(
+        default=False,
+        description="Whether this score uses the current prompt template (Phase 2 feature)",
+    )
+
+
 # ===== Session Control API Models =====
+
 
 class CancelAgentResponse(BaseModel):
     """Response for individual parallel agent cancellation endpoint."""
+
     success: bool = Field(description="Whether the cancellation was successful")
     session_status: str = Field(description="Updated session status after cancellation")
-    stage_status: str = Field(description="Updated parent stage status after re-evaluation")
+    stage_status: str = Field(
+        description="Updated parent stage status after re-evaluation"
+    )
+

--- a/backend/tarsy/models/constants.py
+++ b/backend/tarsy/models/constants.py
@@ -158,7 +158,7 @@ class SystemHealthStatus(Enum):
 class IterationStrategy(str, Enum):
     """
     Available iteration strategies for agent processing.
-    
+
     Each strategy implements a different approach to alert analysis:
     - REACT: Standard ReAct pattern with Think→Action→Observation cycles for complete analysis
     - REACT_STAGE: ReAct pattern for stage-specific analysis within multi-stage chains
@@ -173,6 +173,26 @@ class IterationStrategy(str, Enum):
     NATIVE_THINKING = "native-thinking"   # Gemini native thinking + function calling
     SYNTHESIS = "synthesis"               # Generic synthesis (no tools)
     SYNTHESIS_NATIVE_THINKING = "synthesis-native-thinking"  # Gemini synthesis with thinking
+
+
+class ScoringStatus(Enum):
+    """Status values for session scoring operations."""
+
+    PENDING = "pending"           # Scoring queued but not started
+    IN_PROGRESS = "in_progress"   # LLM currently scoring the session
+    COMPLETED = "completed"       # Scoring finished successfully
+    FAILED = "failed"             # Scoring failed with error
+    TIMED_OUT = "timed_out"       # Scoring timed out
+
+    @classmethod
+    def active_values(cls) -> list['ScoringStatus']:
+        """Active status enum instances (scoring in progress)."""
+        return [cls.PENDING, cls.IN_PROGRESS]
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """All status values as strings."""
+        return [status.value for status in cls]
 
 
 class LLMInteractionType(str, Enum):

--- a/backend/tarsy/repositories/session_score_repository.py
+++ b/backend/tarsy/repositories/session_score_repository.py
@@ -1,0 +1,135 @@
+"""
+Repository for session scoring database operations.
+
+Provides database access layer for session scoring with SQLModel,
+supporting async status tracking and duplicate prevention.
+"""
+
+from typing import List, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, and_, select
+
+from tarsy.models.constants import ScoringStatus
+from tarsy.models.db_models import SessionScore
+from tarsy.repositories.base_repository import BaseRepository
+from tarsy.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SessionScoreRepository:
+    """Repository for session scoring data operations."""
+
+    def __init__(self, session: Session) -> None:
+        """
+        Initialize session score repository with database session.
+
+        Args:
+            session: SQLModel database session
+        """
+        self.session = session
+        self.base_repo = BaseRepository(session, SessionScore)
+
+    def create_session_score(self, score: SessionScore) -> SessionScore:
+        """
+        Create a new session scoring record.
+
+        Prevents duplicate in-progress scores for the same session via
+        partial unique constraint enforced at the database level.
+
+        Args:
+            score: SessionScore instance to create
+
+        Returns:
+            Created SessionScore
+
+        Raises:
+            ValueError: If attempting to create duplicate active scoring
+        """
+        try:
+            return self.base_repo.create(score)
+        except IntegrityError as e:
+            # Partial unique constraint violation (both PostgreSQL and SQLite)
+            self.session.rollback()
+            raise ValueError(
+                f"Cannot create active scoring for session {score.session_id} due to constraint violation: {str(e)}"
+            ) from e
+
+    def get_score_by_id(self, score_id: str) -> Optional[SessionScore]:
+        """Retrieve a session score by ID."""
+        return self.base_repo.get_by_id(score_id)
+
+    def get_scores_for_session(
+        self,
+        session_id: str,
+        status: Optional[ScoringStatus] = None
+    ) -> List[SessionScore]:
+        """Get all scoring attempts for a session, ordered by scored_at_us descending."""
+        statement = select(SessionScore).where(SessionScore.session_id == session_id)
+
+        if status:
+            statement = statement.where(SessionScore.status == status)
+
+        statement = statement.order_by(SessionScore.scored_at_us.desc())
+
+        return list(self.session.exec(statement).all())
+
+    def get_latest_score_for_session(self, session_id: str) -> Optional[SessionScore]:
+        """Get the most recent scoring attempt for a session."""
+        scores = self.get_scores_for_session(session_id)
+        return scores[0] if scores else None
+
+    def get_active_score_for_session(self, session_id: str) -> Optional[SessionScore]:
+        """Get active (pending/in_progress) scoring for a session."""
+        statement = select(SessionScore).where(
+            and_(
+                SessionScore.session_id == session_id,
+                SessionScore.status.in_(ScoringStatus.active_values()),
+            )
+        )
+
+        return self.session.exec(statement).first()
+
+    def update_score(self, score: SessionScore) -> SessionScore:
+        """Update an existing session score."""
+        return self.base_repo.update(score)
+
+    def update_score_status(
+        self,
+        score_id: str,
+        status: ScoringStatus,
+        completed_at_us: Optional[int] = None,
+        error_message: Optional[str] = None,
+        total_score: Optional[int] = None,
+        score_analysis: Optional[str] = None,
+        missing_tools_analysis: Optional[str] = None,
+    ) -> Optional[SessionScore]:
+        """
+        Update scoring status and related fields.
+
+        Convenience method for status transitions with automatic field updates.
+        """
+        score = self.get_score_by_id(score_id)
+        if not score:
+            logger.error(f"Score {score_id} not found for status update")
+            return None
+
+        score.status = status
+
+        if completed_at_us:
+            score.completed_at_us = completed_at_us
+
+        if error_message:
+            score.error_message = error_message
+
+        if total_score is not None:
+            score.total_score = total_score
+
+        if score_analysis:
+            score.score_analysis = score_analysis
+
+        if missing_tools_analysis:
+            score.missing_tools_analysis = missing_tools_analysis
+
+        return self.update_score(score)

--- a/backend/tests/unit/models/test_session_score_models.py
+++ b/backend/tests/unit/models/test_session_score_models.py
@@ -1,0 +1,134 @@
+"""Tests for session scoring models."""
+
+import pytest
+from tarsy.models.constants import ScoringStatus
+from tarsy.models.db_models import SessionScore
+from tarsy.models.api_models import SessionScoreResponse
+from tarsy.utils.timestamp import now_us
+
+
+@pytest.mark.unit
+class TestScoringStatusEnum:
+    """Test ScoringStatus enum."""
+
+    def test_active_values(self):
+        """Test active_values() returns pending and in_progress enum instances."""
+        active = ScoringStatus.active_values()
+        assert ScoringStatus.PENDING in active
+        assert ScoringStatus.IN_PROGRESS in active
+        assert len(active) == 2
+
+    def test_values(self):
+        """Test values() returns all status strings."""
+        all_values = ScoringStatus.values()
+        assert len(all_values) == 5
+        assert "pending" in all_values
+        assert "in_progress" in all_values
+        assert "completed" in all_values
+        assert "failed" in all_values
+        assert "timed_out" in all_values
+
+@pytest.mark.unit
+class TestSessionScore:
+    """Test SessionScore model validation."""
+
+    def test_create_session_score_with_required_fields(self):
+        """Test creating SessionScoreDB with minimum required fields."""
+        score = SessionScore(
+            session_id="test-session-123",
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+
+        assert score.session_id == "test-session-123"
+        assert score.prompt_hash == "abc123"
+        assert score.score_triggered_by == "user:test"
+        assert score.status == ScoringStatus.PENDING
+        assert score.score_id is not None  # Auto-generated
+        assert score.started_at_us is not None  # Auto-generated
+        assert score.scored_at_us is not None  # Auto-generated
+
+    def test_score_id_auto_generation(self):
+        """Test that score_id is auto-generated as UUID."""
+        score1 = SessionScore(
+            session_id="test-session-123",
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        score2 = SessionScore(
+            session_id="test-session-456",
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+
+        assert score1.score_id != score2.score_id
+        assert len(score1.score_id) == 36  # UUID format
+
+@pytest.mark.unit
+class TestSessionScoreResponse:
+    """Test SessionScoreResponse."""
+
+    def test_db_to_api_model_conversion(self):
+        """Test converting SessionScore to SessionScoreResponse."""
+        timestamp = now_us()
+        db_score = SessionScore(
+            score_id="score-123",
+            session_id="session-456",
+            prompt_hash="hash789",
+            total_score=75,
+            score_analysis="Good investigation",
+            missing_tools_analysis="No missing tools",
+            score_triggered_by="user:alice",
+            scored_at_us=timestamp,
+            status=ScoringStatus.COMPLETED,
+            started_at_us=timestamp,
+            completed_at_us=timestamp,
+        )
+
+        # Manually convert DB model to API model
+        api_score = SessionScoreResponse(
+            score_id=db_score.score_id,
+            session_id=db_score.session_id,
+            prompt_hash=db_score.prompt_hash,
+            total_score=db_score.total_score,
+            score_analysis=db_score.score_analysis,
+            missing_tools_analysis=db_score.missing_tools_analysis,
+            score_triggered_by=db_score.score_triggered_by,
+            scored_at_us=db_score.scored_at_us,
+            status=db_score.status,
+            started_at_us=db_score.started_at_us,
+            completed_at_us=db_score.completed_at_us,
+            error_message=db_score.error_message,
+        )
+
+        assert api_score.score_id == "score-123"
+        assert api_score.session_id == "session-456"
+        assert api_score.prompt_hash == "hash789"
+        assert api_score.total_score == 75
+        assert api_score.score_analysis == "Good investigation"
+        assert api_score.status == ScoringStatus.COMPLETED
+
+    def test_current_prompt_used_defaults_to_false(self):
+        """Test that current_prompt_used defaults to False."""
+        db_score = SessionScore(
+            session_id="session-456",
+            prompt_hash="oldhash",
+            score_triggered_by="user:alice",
+            status=ScoringStatus.COMPLETED,
+        )
+
+        api_score = SessionScoreResponse(
+            score_id=db_score.score_id,
+            session_id=db_score.session_id,
+            prompt_hash=db_score.prompt_hash,
+            score_triggered_by=db_score.score_triggered_by,
+            scored_at_us=db_score.scored_at_us,
+            status=db_score.status,
+            started_at_us=db_score.started_at_us,
+        )
+
+        # Defaults to False
+        assert api_score.current_prompt_used is False

--- a/backend/tests/unit/repositories/test_session_score_repository.py
+++ b/backend/tests/unit/repositories/test_session_score_repository.py
@@ -1,0 +1,228 @@
+"""Tests for SessionScoreRepository."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine
+
+from tarsy.models.constants import ScoringStatus
+from tarsy.models.db_models import SessionScore, AlertSession
+from tarsy.repositories.session_score_repository import SessionScoreRepository
+from tarsy.utils.timestamp import now_us
+
+
+@pytest.mark.unit
+class TestSessionScoreRepository:
+    """Test SessionScoreRepository CRUD operations."""
+
+    @pytest.fixture
+    def repository(self, test_database_session):
+        """Create repository instance."""
+        return SessionScoreRepository(test_database_session)
+
+    @pytest.fixture
+    def sample_alert_session(self, test_database_session):
+        """Create sample AlertSession for FK constraint."""
+        session = AlertSession(
+            session_id="test-session-123",
+            alert_data={},
+            agent_type="KubernetesAgent",
+            status="completed",
+            started_at_us=now_us(),
+            chain_id="test-chain-123",
+        )
+        test_database_session.add(session)
+        test_database_session.commit()
+        return session
+
+    def test_create_session_score_success(self, repository, sample_alert_session):
+        """Test successful score creation."""
+        score = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+
+        created = repository.create_session_score(score)
+
+        assert created is not None
+        assert created.score_id is not None
+        assert created.session_id == sample_alert_session.session_id
+        assert created.status == ScoringStatus.PENDING
+
+    def test_create_duplicate_active_score_raises_error(
+        self, repository, sample_alert_session
+    ):
+        """Test that creating duplicate active score raises ValueError."""
+        score1 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        repository.create_session_score(score1)
+
+        # Attempt duplicate
+        score2 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.IN_PROGRESS,
+        )
+
+        with pytest.raises(ValueError, match="due to constraint violation"):
+            repository.create_session_score(score2)
+
+    def test_create_allows_new_score_after_previous_completed(
+        self, repository, sample_alert_session
+    ):
+        """Test that new score can be created after previous completes."""
+        # Create and complete first score
+        score1 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.COMPLETED,
+            completed_at_us=now_us(),
+        )
+        repository.create_session_score(score1)
+
+        # Create new score - should succeed
+        score2 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="def456",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        created = repository.create_session_score(score2)
+
+        assert created is not None
+        assert created.score_id != score1.score_id
+
+    def test_get_score_by_id_found(self, repository, sample_alert_session):
+        """Test retrieving score by ID."""
+        score = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        created = repository.create_session_score(score)
+
+        retrieved = repository.get_score_by_id(created.score_id)
+
+        assert retrieved is not None
+        assert retrieved.score_id == created.score_id
+
+    def test_get_score_by_id_not_found(self, repository):
+        """Test that non-existent score returns None."""
+        retrieved = repository.get_score_by_id("nonexistent-id")
+        assert retrieved is None
+
+    def test_get_latest_score_for_session(self, repository, sample_alert_session):
+        """Test getting most recent score."""
+        # Create two scores
+        score1 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.COMPLETED,
+            scored_at_us=now_us() - 1000000,  # Earlier
+        )
+        score2 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="def456",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+            scored_at_us=now_us(),  # Later
+        )
+        repository.create_session_score(score1)
+        repository.create_session_score(score2)
+
+        latest = repository.get_latest_score_for_session(
+            sample_alert_session.session_id
+        )
+
+        assert latest is not None
+        assert latest.prompt_hash == "def456"  # Most recent
+
+    def test_get_active_score_for_session(self, repository, sample_alert_session):
+        """Test getting active score (pending/in_progress)."""
+        # Create completed score
+        score1 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.COMPLETED,
+        )
+        repository.create_session_score(score1)
+
+        # Should return None (no active)
+        active = repository.get_active_score_for_session(
+            sample_alert_session.session_id
+        )
+        assert active is None
+
+        # Create pending score
+        score2 = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="def456",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        repository.create_session_score(score2)
+
+        # Should return the pending score
+        active = repository.get_active_score_for_session(
+            sample_alert_session.session_id
+        )
+        assert active is not None
+        assert active.status == ScoringStatus.PENDING
+
+    def test_update_score_status_to_completed(self, repository, sample_alert_session):
+        """Test updating score status to completed with results."""
+        score = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.PENDING,
+        )
+        created = repository.create_session_score(score)
+
+        # Update to completed
+        updated = repository.update_score_status(
+            score_id=created.score_id,
+            status=ScoringStatus.COMPLETED,
+            completed_at_us=now_us(),
+            total_score=85,
+            score_analysis="Excellent investigation",
+            missing_tools_analysis="No tools missing",
+        )
+
+        assert updated is not None
+        assert updated.status == ScoringStatus.COMPLETED
+        assert updated.total_score == 85
+        assert updated.completed_at_us is not None
+
+    def test_update_score_status_to_failed(self, repository, sample_alert_session):
+        """Test updating score status to failed with error message."""
+        score = SessionScore(
+            session_id=sample_alert_session.session_id,
+            prompt_hash="abc123",
+            score_triggered_by="user:test",
+            status=ScoringStatus.IN_PROGRESS,
+        )
+        created = repository.create_session_score(score)
+
+        # Update to failed
+        updated = repository.update_score_status(
+            score_id=created.score_id,
+            status=ScoringStatus.FAILED,
+            completed_at_us=now_us(),
+            error_message="LLM API timeout",
+        )
+
+        assert updated is not None
+        assert updated.status == ScoringStatus.FAILED
+        assert updated.error_message == "LLM API timeout"
+        assert updated.completed_at_us is not None

--- a/docs/enhancements/pending/EP-0028-phase-1-scoring-api.md
+++ b/docs/enhancements/pending/EP-0028-phase-1-scoring-api.md
@@ -264,7 +264,7 @@ Clients subscribe to channels via existing WebSocket infrastructure. Real-time u
 
 **Goal:** Establish data structures and persistence layer
 
-* [ ] Create Alembic migration for session_scores table
+* [x] Create Alembic migration for session_scores table
   * Table name: `session_scores`
   * Columns:
     * `score_id` (UUID, primary key)
@@ -285,27 +285,27 @@ Clients subscribe to channels via existing WebSocket infrastructure. Real-time u
   * Forward migration: CREATE TABLE with indexes and constraints
   * Rollback migration: DROP TABLE
 
-* [ ] Implement database model (SQLModel): SessionScoreDB
+* [x] Implement database model (SQLModel): SessionScoreDB
   * Main score record with freeform text fields
   * Includes async fields: status, started_at_us, completed_at_us, error_message
   * Maps to session_scores table
 
-* [ ] Implement API model (Pydantic): SessionScore
+* [x] Implement API model (Pydantic): SessionScore
   * API response model with all database fields including status
   * Computed field: `current_prompt_used` (boolean)
     * Compares stored `prompt_hash` to current hardcoded prompts hash
     * Current hash computed once at TARSy startup (set to 0 in this phase)
 
-* [ ] Implement ScoringStatus enum (similar to AlertSessionStatus)
+* [x] Implement ScoringStatus enum (similar to AlertSessionStatus)
   * Values: PENDING, IN_PROGRESS, COMPLETED, FAILED
   * Helper method: `terminal_values()` returns [COMPLETED, FAILED]
 
-* [ ] Create repository layer with simple CRUD operations
+* [x] Create repository layer with simple CRUD operations
   * Basic CRUD for session_scores table
   * Hash comparison logic for `current_prompt_used`
   * Database to API model mapping
 
-* [ ] Test database schema and basic model operations
+* [x] Test database schema and basic model operations
   * Unit tests for model validation
   * Migration up/down testing
 


### PR DESCRIPTION
This lays down the foundational types and db tables for the session scoring according to [EP-0028](https://github.com/codeready-toolchain/tarsy-bot/blob/edfa2b729abd9faaf01cf77bd79909a622a1557f/docs/enhancements/pending/EP-0028-phase-1-scoring-api.md).

Part of the PR stack:
* #243
* #244 
* #245 
* #246 
* #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session scoring capabilities with comprehensive status tracking (pending, in progress, completed, failed, timed out)
  * Introduced scoring API endpoints to create, retrieve, and manage session scores
  * Added detailed scoring analysis including performance metrics and missing tools identification

* **Tests**
  * Expanded test coverage for scoring models and repository operations

* **Documentation**
  * Completed Phase 1 scoring API design
<!-- end of auto-generated comment: release notes by coderabbit.ai -->