### PR TITLE
refactor: Pull db logic out of BaseHistoryInfra

### DIFF
--- a/backend/tarsy/repositories/retries.py
+++ b/backend/tarsy/repositories/retries.py
@@ -1,0 +1,245 @@
+import asyncio
+import logging
+import random
+import time
+from typing import Awaitable, Callable, Final, List, Optional, TypeVar
+
+from sqlalchemy.exc import DBAPIError
+
+from tarsy.repositories.base_repository import DatabaseManager
+
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+# SQLite retryable error keywords
+SQLITE_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
+    "database is locked",
+    "database disk image is malformed",
+    "sqlite3.operationalerror",
+    "database table is locked",
+)
+
+# PostgreSQL retryable error keywords (fallback when SQLSTATE unavailable)
+POSTGRESQL_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
+    "serialization failure",
+    "deadlock detected",
+    "could not obtain lock",
+    "too many connections",
+    "could not connect",
+    "connection refused",
+    "server closed the connection",
+    "connection timed out",
+    "connection reset",
+)
+
+# Common retryable error keywords (both SQLite and PostgreSQL)
+COMMON_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
+    "connection timeout",
+    "connection pool",
+    "connection closed",
+)
+
+# PostgreSQL SQLSTATE codes that indicate retryable transient errors
+# 40001: serialization_failure
+# 40P01: deadlock_detected
+# 55P03: lock_not_available
+# 53300: too_many_connections
+# 57014: query_canceled
+# Class 08: connection exceptions (08000, 08003, 08006, etc.)
+POSTGRESQL_RETRYABLE_SQLSTATES: Final[frozenset[str]] = frozenset(
+    {
+        "40001",  # serialization_failure
+        "40P01",  # deadlock_detected
+        "55P03",  # lock_not_available
+        "53300",  # too_many_connections
+        "57014",  # query_canceled
+    }
+)
+
+POSTGRESQL_RETRYABLE_SQLSTATE_CLASS: Final[str] = "08"  # Connection exception class
+
+
+class DatabaseRetries:
+    def __init__(
+        self,
+        *,
+        db_manager: DatabaseManager,
+        max_retries: int,
+        base_delay: float,
+        max_delay: float,
+        non_retriable_ops: Optional[List[str]] = None,
+    ):
+        self.db_manager = db_manager
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        if non_retriable_ops is None:
+            self._non_retriable_ops = []
+        else:
+            self._non_retriable_ops = non_retriable_ops
+
+    def database_operation(
+        self,
+        operation_name: str,
+        operation_func: Callable[[], T],
+        *,
+        treat_none_as_success: bool = False,
+    ) -> Optional[T]:
+        """Retry database operations with exponential backoff."""
+        last_exception = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                result = operation_func()
+                if result is not None:
+                    return result
+                if treat_none_as_success:
+                    return None
+                logger.warning(
+                    f"Database operation '{operation_name}' returned None on attempt {attempt + 1}"
+                )
+
+            except Exception as e:
+                last_exception = e
+                is_retryable = self._is_retryable_error(e)
+
+                if operation_name in self._non_retriable_ops:
+                    logger.warning(
+                        f"Not retrying {operation_name} after database error: {str(e)}"
+                    )
+                    return None
+
+                if not is_retryable or attempt == self.max_retries:
+                    logger.error(
+                        f"Database operation '{operation_name}' failed after {attempt + 1} attempts: {str(e)}"
+                    )
+                    return None
+
+                delay = min(self.base_delay * (2**attempt), self.max_delay)
+                jitter = random.uniform(0, delay * 0.1)
+                total_delay = delay + jitter
+
+                logger.warning(
+                    f"Database operation '{operation_name}' failed on attempt {attempt + 1}, retrying in {total_delay:.2f}s: {str(e)}"
+                )
+                time.sleep(total_delay)
+
+        logger.error(
+            f"Database operation '{operation_name}' failed after all retries. Last error: {str(last_exception)}"
+        )
+        return None
+
+    async def async_database_operation(
+        self,
+        operation_name: str,
+        operation_func: Callable[[], Awaitable[T]],
+        *,
+        treat_none_as_success: bool = False,
+    ) -> Optional[T]:
+        """Async retry database operations with exponential backoff."""
+        last_exception = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                result = await operation_func()
+                if result is not None:
+                    return result
+                if treat_none_as_success:
+                    return None
+                logger.warning(
+                    f"Database operation '{operation_name}' returned None on attempt {attempt + 1}"
+                )
+            except Exception as e:
+                last_exception = e
+                is_retryable = self._is_retryable_error(e)
+                if operation_name in self._non_retriable_ops:
+                    logger.warning(
+                        "Not retrying {operation_name} after database error: %s",
+                        str(e),
+                    )
+                    return None
+                if not is_retryable or attempt == self.max_retries:
+                    logger.error(
+                        "Database operation '%s' failed after %d attempts: %s",
+                        operation_name,
+                        attempt + 1,
+                        str(e),
+                    )
+                    return None
+                delay = min(self.base_delay * (2**attempt), self.max_delay)
+                jitter = random.uniform(0, delay * 0.1)
+                await asyncio.sleep(delay + jitter)
+        logger.error(
+            "Database operation '%s' failed after all retries. Last error: %s",
+            operation_name,
+            str(last_exception),
+        )
+        return None
+
+    def _is_postgresql(self) -> bool:
+        """Check if the database backend is PostgreSQL."""
+        if not self.db_manager or not self.db_manager.database_url:
+            return False
+        url = self.db_manager.database_url.lower()
+        return url.startswith("postgresql") or url.startswith("postgres")
+
+    def _get_sqlstate(self, exc: Exception) -> Optional[str]:
+        """
+        Extract SQLSTATE code from a database exception.
+
+        For PostgreSQL via psycopg2/psycopg, the SQLSTATE is available in
+        orig.pgcode. Returns None if SQLSTATE cannot be extracted.
+        """
+        # SQLAlchemy wraps DBAPI errors in DBAPIError
+        if isinstance(exc, DBAPIError) and exc.orig is not None:
+            orig = exc.orig
+            # psycopg2/psycopg3 provide pgcode attribute
+            if hasattr(orig, "pgcode") and orig.pgcode:
+                return str(orig.pgcode)
+            # Some drivers provide sqlstate attribute
+            if hasattr(orig, "sqlstate") and orig.sqlstate:
+                return str(orig.sqlstate)
+        return None
+
+    def _is_retryable_error(self, exc: Exception) -> bool:
+        """
+        Determine if a database error is transient and worth retrying.
+
+        For PostgreSQL:
+            - First checks SQLSTATE codes (40001, 40P01, 55P03, 53300, 57014, class 08*)
+            - Falls back to message pattern matching if SQLSTATE unavailable
+
+        For SQLite:
+            - Uses message pattern matching for locking and operational errors
+
+        Common patterns (connection issues) are checked for both backends.
+        """
+        error_msg = str(exc).lower()
+
+        # Check common retryable patterns (both backends)
+        if any(keyword in error_msg for keyword in COMMON_RETRYABLE_KEYWORDS):
+            return True
+
+        if self._is_postgresql():
+            # PostgreSQL: Check SQLSTATE first
+            sqlstate = self._get_sqlstate(exc)
+            if sqlstate:
+                # Check specific SQLSTATE codes
+                if sqlstate in POSTGRESQL_RETRYABLE_SQLSTATES:
+                    logger.debug(f"Retryable PostgreSQL SQLSTATE: {sqlstate}")
+                    return True
+                # Check SQLSTATE class 08 (connection exceptions)
+                if sqlstate.startswith(POSTGRESQL_RETRYABLE_SQLSTATE_CLASS):
+                    logger.debug(
+                        f"Retryable PostgreSQL connection SQLSTATE: {sqlstate}"
+                    )
+                    return True
+
+            # PostgreSQL: Fall back to message patterns if SQLSTATE unavailable
+            if any(keyword in error_msg for keyword in POSTGRESQL_RETRYABLE_KEYWORDS):
+                return True
+        else:
+            # SQLite: Use message pattern matching
+            if any(keyword in error_msg for keyword in SQLITE_RETRYABLE_KEYWORDS):
+                return True
+
+        return False

--- a/backend/tarsy/services/base_service.py
+++ b/backend/tarsy/services/base_service.py
@@ -1,0 +1,172 @@
+"""
+asdf
+"""
+
+from abc import ABC
+import asyncio
+import logging
+from contextlib import asynccontextmanager, contextmanager, suppress
+from typing import (
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Generator,
+    List,
+    Optional,
+    TypeVar,
+)
+from warnings import deprecated
+
+from sqlmodel import Session
+
+from tarsy.config.settings import Settings, get_settings
+from tarsy.repositories.base_repository import DatabaseManager
+from tarsy.repositories.retries import DatabaseRetries
+
+logger = logging.getLogger(__name__)
+R = TypeVar("R")  # repository type
+T = TypeVar("T")  # type returned from a retried function
+
+
+class BaseService[R](ABC):
+    def __init__(self, repository_factory: Callable[[Session], R], non_retriable_ops: Optional[List[str]] = None):
+        self.settings: Settings = get_settings()
+        self.db_manager: Optional[DatabaseManager] = None
+        self._initialization_attempted: bool = False
+        self._is_healthy: bool = False
+        self.max_retries: int = 3
+        self.base_delay: float = 0.1
+        self.max_delay: float = 2.0
+        self.retries: Optional[DatabaseRetries] = None
+        self._repository_factory = repository_factory
+        self._non_retriable_ops=non_retriable_ops
+
+    @deprecated("use _ready_for_testing instead")
+    def _set_healthy_for_testing(self, is_healthy: bool = True) -> None:
+        self._ready_for_testing(is_healthy)
+
+    def _ready_for_testing(self, is_healthy: bool = True):
+        """
+        Set infrastructure health state for testing purposes.
+
+        This method provides a clean interface for tests to configure the
+        infrastructure state without directly accessing private attributes.
+        Only use this in test code.
+
+        Args:
+            is_healthy: Whether to mark the infrastructure as healthy.
+        """
+        self._initialization_attempted = True
+        self._is_healthy = is_healthy
+        if self.retries is None:
+            self.retries = DatabaseRetries(
+                db_manager=self.db_manager,
+                max_retries=self.max_retries,
+                base_delay=self.base_delay,
+                max_delay=self.max_delay,
+                non_retriable_ops=self._non_retriable_ops
+            )
+
+    def _initialize(self):
+        """Initialize database connection and schema."""
+        if self._initialization_attempted:
+            return self._is_healthy
+
+        self._initialization_attempted = True
+
+        try:
+            self.db_manager = DatabaseManager(self.settings.database_url)
+            self.db_manager.initialize()
+            self.db_manager.create_tables()
+            self.retries = DatabaseRetries(
+                db_manager=self.db_manager,
+                max_retries=self.max_retries,
+                base_delay=self.base_delay,
+                max_delay=self.max_delay,
+                non_retriable_ops=self._non_retriable_ops,
+            )
+            self._is_healthy = True
+
+        except Exception as e:
+            self._is_healthy = False
+            raise e
+
+    @contextmanager
+    def get_repository(self) -> Generator[Optional[R], None, None]:
+        """Context manager for getting repository with error handling."""
+        if not self._is_healthy:
+            yield None
+            return
+
+        session = None
+        repository = None
+        try:
+            if not self.db_manager:
+                yield None
+                return
+
+            session = self.db_manager.get_session()
+            repository = self._repository_factory(session)
+            yield repository
+
+        except Exception as e:
+            logger.error(f"Repository error: {str(e)}")
+            if session:
+                with suppress(Exception):
+                    session.rollback()
+
+        finally:
+            if session:
+                try:
+                    session.close()
+                except Exception as e:
+                    logger.error(f"Error closing database session: {str(e)}")
+
+    def _retry_database_operation(
+        self,
+        operation_name: str,
+        operation_func: Callable[[], T],
+        *,
+        treat_none_as_success: bool = False,
+    ) -> Optional[T]:
+        """Retry database operations with exponential backoff.
+
+        Raises:
+            RuntimeError: If service is not properly initialized (retries is None).
+        """
+        if self.retries is None:
+            raise RuntimeError(
+                f"Service not properly initialized: cannot perform '{operation_name}'. "
+                f"Call initialize() or _ready_for_testing() first."
+            )
+
+        return self.retries.database_operation(
+            operation_name,
+            operation_func,
+            treat_none_as_success=treat_none_as_success,
+        )
+
+    async def _retry_database_operation_async(
+        self,
+        operation_name: str,
+        operation_func: Callable[[], T],
+        *,
+        treat_none_as_success: bool = False,
+    ) -> Optional[T]:
+        """Async retry database operations with exponential backoff.
+
+        Raises:
+            RuntimeError: If service is not properly initialized (retries is None).
+        """
+        if self.retries is None:
+            raise RuntimeError(
+                f"Service not properly initialized: cannot perform '{operation_name}'. "
+                f"Call initialize() or _ready_for_testing() first."
+            )
+
+        async def f():
+            return await asyncio.to_thread(operation_func)
+
+        return await self.retries.async_database_operation(
+            operation_name, f, treat_none_as_success=treat_none_as_success
+        )

--- a/backend/tarsy/services/history_service/base_infrastructure.py
+++ b/backend/tarsy/services/history_service/base_infrastructure.py
@@ -1,66 +1,14 @@
 """Base infrastructure for history service operations."""
 
-import asyncio
 import logging
-import random
-import time
-from contextlib import contextmanager, suppress
-from typing import Callable, Final, Generator, Optional, TypeVar
+from typing import  Final, TypeVar
 
-from sqlalchemy.exc import DBAPIError
-
-from tarsy.config.settings import Settings, get_settings
-from tarsy.repositories.base_repository import DatabaseManager
 from tarsy.repositories.history_repository import HistoryRepository
+from tarsy.services.base_service import BaseService
 
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
-
-# SQLite retryable error keywords
-SQLITE_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
-    'database is locked',
-    'database disk image is malformed',
-    'sqlite3.operationalerror',
-    'database table is locked',
-)
-
-# PostgreSQL retryable error keywords (fallback when SQLSTATE unavailable)
-POSTGRESQL_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
-    'serialization failure',
-    'deadlock detected',
-    'could not obtain lock',
-    'too many connections',
-    'could not connect',
-    'connection refused',
-    'server closed the connection',
-    'connection timed out',
-    'connection reset',
-)
-
-# Common retryable error keywords (both SQLite and PostgreSQL)
-COMMON_RETRYABLE_KEYWORDS: Final[tuple[str, ...]] = (
-    'connection timeout',
-    'connection pool',
-    'connection closed',
-)
-
-# PostgreSQL SQLSTATE codes that indicate retryable transient errors
-# 40001: serialization_failure
-# 40P01: deadlock_detected
-# 55P03: lock_not_available
-# 53300: too_many_connections
-# 57014: query_canceled
-# Class 08: connection exceptions (08000, 08003, 08006, etc.)
-POSTGRESQL_RETRYABLE_SQLSTATES: Final[frozenset[str]] = frozenset({
-    '40001',  # serialization_failure
-    '40P01',  # deadlock_detected
-    '55P03',  # lock_not_available
-    '53300',  # too_many_connections
-    '57014',  # query_canceled
-})
-
-POSTGRESQL_RETRYABLE_SQLSTATE_CLASS: Final[str] = '08'  # Connection exception class
 
 
 class _NoInteractionsSentinel:
@@ -72,222 +20,19 @@ class _NoInteractionsSentinel:
 NO_INTERACTIONS: Final[_NoInteractionsSentinel] = _NoInteractionsSentinel()
 
 
-class BaseHistoryInfra:
+class BaseHistoryInfra(BaseService[HistoryRepository]):
     """Core infrastructure: DB access, retry logic, health tracking."""
     
     def __init__(self) -> None:
-        self.settings: Settings = get_settings()
-        self.db_manager: Optional[DatabaseManager] = None
-        self._initialization_attempted: bool = False
-        self._is_healthy: bool = False
-        self.max_retries: int = 3
-        self.base_delay: float = 0.1
-        self.max_delay: float = 2.0
-    
-    def _set_healthy_for_testing(self, is_healthy: bool = True) -> None:
-        """
-        Set infrastructure health state for testing purposes.
-        
-        This method provides a clean interface for tests to configure the
-        infrastructure state without directly accessing private attributes.
-        Only use this in test code.
-        
-        Args:
-            is_healthy: Whether to mark the infrastructure as healthy.
-        """
-        self._initialization_attempted = True
-        self._is_healthy = is_healthy
+        super().__init__(HistoryRepository, non_retriable_ops=["create_session"])
     
     def initialize(self) -> bool:
         """Initialize database connection and schema."""
-        if self._initialization_attempted:
-            return self._is_healthy
-            
-        self._initialization_attempted = True
-        
         try:
-            self.db_manager = DatabaseManager(self.settings.database_url)
-            self.db_manager.initialize()
-            self.db_manager.create_tables()
-            self._is_healthy = True
+            super()._initialize()
             logger.info("History service initialized successfully")
             return True
-            
         except Exception as e:
             logger.error(f"Failed to initialize history service: {str(e)}")
             logger.info("History service will operate in degraded mode (logging only)")
-            self._is_healthy = False
             return False
-    
-    def _is_postgresql(self) -> bool:
-        """Check if the database backend is PostgreSQL."""
-        if not self.db_manager or not self.db_manager.database_url:
-            return False
-        url = self.db_manager.database_url.lower()
-        return url.startswith('postgresql') or url.startswith('postgres')
-    
-    def _get_sqlstate(self, exc: Exception) -> Optional[str]:
-        """
-        Extract SQLSTATE code from a database exception.
-        
-        For PostgreSQL via psycopg2/psycopg, the SQLSTATE is available in
-        orig.pgcode. Returns None if SQLSTATE cannot be extracted.
-        """
-        # SQLAlchemy wraps DBAPI errors in DBAPIError
-        if isinstance(exc, DBAPIError) and exc.orig is not None:
-            orig = exc.orig
-            # psycopg2/psycopg3 provide pgcode attribute
-            if hasattr(orig, 'pgcode') and orig.pgcode:
-                return str(orig.pgcode)
-            # Some drivers provide sqlstate attribute
-            if hasattr(orig, 'sqlstate') and orig.sqlstate:
-                return str(orig.sqlstate)
-        return None
-    
-    def _is_retryable_error(self, exc: Exception) -> bool:
-        """
-        Determine if a database error is transient and worth retrying.
-        
-        For PostgreSQL:
-            - First checks SQLSTATE codes (40001, 40P01, 55P03, 53300, 57014, class 08*)
-            - Falls back to message pattern matching if SQLSTATE unavailable
-        
-        For SQLite:
-            - Uses message pattern matching for locking and operational errors
-        
-        Common patterns (connection issues) are checked for both backends.
-        """
-        error_msg = str(exc).lower()
-        
-        # Check common retryable patterns (both backends)
-        if any(keyword in error_msg for keyword in COMMON_RETRYABLE_KEYWORDS):
-            return True
-        
-        if self._is_postgresql():
-            # PostgreSQL: Check SQLSTATE first
-            sqlstate = self._get_sqlstate(exc)
-            if sqlstate:
-                # Check specific SQLSTATE codes
-                if sqlstate in POSTGRESQL_RETRYABLE_SQLSTATES:
-                    logger.debug(f"Retryable PostgreSQL SQLSTATE: {sqlstate}")
-                    return True
-                # Check SQLSTATE class 08 (connection exceptions)
-                if sqlstate.startswith(POSTGRESQL_RETRYABLE_SQLSTATE_CLASS):
-                    logger.debug(f"Retryable PostgreSQL connection SQLSTATE: {sqlstate}")
-                    return True
-            
-            # PostgreSQL: Fall back to message patterns if SQLSTATE unavailable
-            if any(keyword in error_msg for keyword in POSTGRESQL_RETRYABLE_KEYWORDS):
-                return True
-        else:
-            # SQLite: Use message pattern matching
-            if any(keyword in error_msg for keyword in SQLITE_RETRYABLE_KEYWORDS):
-                return True
-        
-        return False
-    
-    @contextmanager
-    def get_repository(self) -> Generator[Optional[HistoryRepository], None, None]:
-        """Context manager for getting repository with error handling."""
-        if not self._is_healthy:
-            yield None
-            return
-            
-        session = None
-        repository = None
-        try:
-            if not self.db_manager:
-                yield None
-                return
-                
-            session = self.db_manager.get_session()
-            repository = HistoryRepository(session)
-            yield repository
-            
-        except Exception as e:
-            logger.error(f"History repository error: {str(e)}")
-            if session:
-                with suppress(Exception):
-                    session.rollback()
-            
-        finally:
-            if session:
-                try:
-                    session.close()
-                except Exception as e:
-                    logger.error(f"Error closing database session: {str(e)}")
-    
-    def _retry_database_operation(
-        self,
-        operation_name: str,
-        operation_func: Callable[[], T],
-        *,
-        treat_none_as_success: bool = False,
-    ) -> Optional[T]:
-        """Retry database operations with exponential backoff."""
-        last_exception = None
-        
-        for attempt in range(self.max_retries + 1):
-            try:
-                result = operation_func()
-                if result is not None:
-                    return result
-                if treat_none_as_success:
-                    return None
-                logger.warning(
-                    f"Database operation '{operation_name}' returned None on attempt {attempt + 1}"
-                )
-                
-            except Exception as e:
-                last_exception = e
-                is_retryable = self._is_retryable_error(e)
-                
-                if operation_name == "create_session":
-                    logger.warning(f"Not retrying session creation after database error to prevent duplicates: {str(e)}")
-                    return None
-                
-                if not is_retryable or attempt == self.max_retries:
-                    logger.error(f"Database operation '{operation_name}' failed after {attempt + 1} attempts: {str(e)}")
-                    return None
-                
-                delay = min(self.base_delay * (2 ** attempt), self.max_delay)
-                jitter = random.uniform(0, delay * 0.1)
-                total_delay = delay + jitter
-                
-                logger.warning(f"Database operation '{operation_name}' failed on attempt {attempt + 1}, retrying in {total_delay:.2f}s: {str(e)}")
-                time.sleep(total_delay)
-        
-        logger.error(f"Database operation '{operation_name}' failed after all retries. Last error: {str(last_exception)}")
-        return None
-    
-    async def _retry_database_operation_async(
-        self,
-        operation_name: str,
-        operation_func: Callable[[], T],
-        *,
-        treat_none_as_success: bool = False,
-    ) -> Optional[T]:
-        """Async retry database operations with exponential backoff."""
-        last_exception = None
-        for attempt in range(self.max_retries + 1):
-            try:
-                result = await asyncio.to_thread(operation_func)
-                if result is not None:
-                    return result
-                if treat_none_as_success:
-                    return None
-                logger.warning(f"Database operation '{operation_name}' returned None on attempt {attempt + 1}")
-            except Exception as e:
-                last_exception = e
-                is_retryable = self._is_retryable_error(e)
-                if operation_name == "create_session":
-                    logger.warning("Not retrying session creation after database error to prevent duplicates: %s", str(e))
-                    return None
-                if not is_retryable or attempt == self.max_retries:
-                    logger.error("Database operation '%s' failed after %d attempts: %s", operation_name, attempt + 1, str(e))
-                    return None
-                delay = min(self.base_delay * (2 ** attempt), self.max_delay)
-                jitter = random.uniform(0, delay * 0.1)
-                await asyncio.sleep(delay + jitter)
-        logger.error("Database operation '%s' failed after all retries. Last error: %s", operation_name, str(last_exception))
-        return None

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1236,7 +1236,7 @@ def history_service_with_test_db(history_test_database_engine):
     mock_settings.database_url = "sqlite:///:memory:"
     mock_settings.history_retention_days = 90
     
-    with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+    with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
         service = HistoryService()
         
         # CRITICAL: Replace the DatabaseManager's engine with our test engine

--- a/backend/tests/integration/test_history_integration.py
+++ b/backend/tests/integration/test_history_integration.py
@@ -106,7 +106,7 @@ class TestHistoryServiceIntegration:
         mock_settings.database_url = "sqlite:///:memory:"
         mock_settings.history_retention_days = 90
         
-        with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+        with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
             service = HistoryService()
             
             # CRITICAL: Replace the DatabaseManager's engine with our test engine

--- a/backend/tests/unit/services/test_history_service_cancellation.py
+++ b/backend/tests/unit/services/test_history_service_cancellation.py
@@ -26,7 +26,7 @@ class TestHistoryServiceCancellation:
     @pytest.fixture
     def history_service(self, mock_settings):
         """Create HistoryService instance with mocked dependencies."""
-        with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+        with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
             service = HistoryService()
             service._infra._set_healthy_for_testing()
             return service

--- a/backend/tests/unit/services/test_history_service_optional_metadata.py
+++ b/backend/tests/unit/services/test_history_service_optional_metadata.py
@@ -29,7 +29,7 @@ class TestHistoryServiceOptionalMetadata:
     @pytest.fixture
     def history_service(self, mock_settings):
         """Create HistoryService instance with mocked dependencies."""
-        with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+        with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
             service = HistoryService()
             service._infra._set_healthy_for_testing()
             return service

--- a/backend/tests/unit/services/test_history_service_paused_stages.py
+++ b/backend/tests/unit/services/test_history_service_paused_stages.py
@@ -52,7 +52,7 @@ class TestGetPausedStages:
     @pytest.fixture
     def history_service(self, mock_settings):
         """Create HistoryService instance with mocked dependencies."""
-        with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+        with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
             service = HistoryService()
             service._infra._set_healthy_for_testing()
             return service
@@ -267,7 +267,7 @@ class TestCancelAllPausedStages:
     @pytest.fixture
     def history_service(self, mock_settings):
         """Create HistoryService instance with mocked dependencies."""
-        with patch('tarsy.services.history_service.base_infrastructure.get_settings', return_value=mock_settings):
+        with patch('tarsy.services.base_service.get_settings', return_value=mock_settings):
             service = HistoryService()
             service._infra._set_healthy_for_testing()
             return service


### PR DESCRIPTION
… such that it can be reused by other services.

This is a relatively simple refactoring that pulls database and repository related functionality out of `BaseHistoryInfra` into a `BaseService` a base class reusable by other services and `DatabaseRetries` that concentrates the retry logic into one place.

This is support work for session scoring but stands on its own so I'm not adding it into the PR stack for the session scoring.